### PR TITLE
feat: update visualizer when opts changed on runtime

### DIFF
--- a/visualizer.lua
+++ b/visualizer.lua
@@ -136,14 +136,6 @@ local axis_1 = "image/png;base64," ..
 local options = require 'mp.options'
 local msg     = require 'mp.msg'
 
-options.read_options(opts)
-opts.height = math.min(12, math.max(4, opts.height))
-opts.height = math.floor(opts.height)
-
-if not opts.forcewindow and mp.get_property('force-window') == "no" then
-    return
-end
-
 local function get_visualizer(name, quality, vtrack)
     local w, h, fps
 
@@ -328,6 +320,14 @@ local function visualizer_hook()
     if lavfi ~= "" and lavfi ~= mp.get_property("lavfi-complex", "") then
         mp.set_property("file-local-options/lavfi-complex", lavfi)
     end
+end
+
+options.read_options(opts, nil, visualizer_hook)
+opts.height = math.min(12, math.max(4, opts.height))
+opts.height = math.floor(opts.height)
+
+if not opts.forcewindow and mp.get_property('force-window') == "no" then
+    return
 end
 
 mp.add_hook("on_preloaded", 50, visualizer_hook)


### PR DESCRIPTION
The `options.read_options` will not, by default, update changes if opts changed on runtime. Unless we pass in the third optional parameter, `on_update`. Quoting from the man pages:

> The `on_update` parameter  enables run-time updates of all matching
option values via the script-opts option/property. If any of the matching options changes, the values in the table (which was originally passed to the function) are changed, and on_update(list) is called.

With this commit, the visualizer will now update when the opts changed on runtime. This will also allow user to, for example, create a keybind that will toggle the visualizer on and off, *not cycling them*. Like so:
```
c cycle-values script-opts "visualizer-name=off" "visualizer-name=showcqtbar"
```